### PR TITLE
Docs: Client Trial Guide + production URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ npm run dev
 
 Visit `http://localhost:3000` to access the Belmont SEO Lab.
 
+Production (client trial):
+- App: https://seo-lab-echoexes-projects.vercel.app
+- See `docs/CLIENT_TRIAL_GUIDE.md` for a link bundle and a 10‑minute demo script.
+
 ### Production Deployment
 
 ```bash
@@ -62,9 +66,20 @@ npm install -g vercel
 vercel --prod
 ```
 
+See docs/DEPLOYMENT.md for a full deployment runbook and rollback steps.
+
 Environment variables:
 - `NEXT_PUBLIC_SITE_BASE`: Set to the deployed base URL (e.g. `https://belmont-seo-lab.vercel.app`). Used for OpenGraph, robots, and sitemap.
 - `NEXT_PUBLIC_ALLOW_INDEXING`: Set to `true` when you want search engines to index the site. Defaults to noindex when unset.
+
+### Security & Secrets Management
+- Do not commit secrets. Local env files (`.env*.local`) are ignored by Git.
+- Rotate `OPENAI_API_KEY` before client delivery:
+  - Generate a new key in your OpenAI account.
+  - Update the key in your hosting provider’s secrets manager for production and staging.
+  - Remove/replace any local test keys in `.env.local` as needed.
+- Prefer provider-managed env vars over committing files. Use the templates in `env/.env.production.example` and `env/.env.staging.example` for reference only.
+- In CI (GitHub Actions), set secrets under repository Settings → Secrets and variables → Actions, and expose them via `env:` in the workflow if required by tests.
 
 ---
 
@@ -183,6 +198,13 @@ The Belmont SEO Lab comes pre-configured with Belmont-specific data and settings
 - Veterans Day specials
 - Local event participation
 - Seasonal service campaigns
+
+---
+
+## 📦 Handoff & Client Guide
+
+- Review the Client Handoff Checklist at docs/CLIENT_HANDOFF_CHECKLIST.md to verify production readiness.
+- Use docs/DEMO_GUIDE.md to walk through the key flows with stakeholders.
 
 #### **5. 🎨 Social Media Content Studio**
 **Why It Matters:** Consistent, professional social media content builds your brand and keeps customers engaged. Show off your work, share tips, and remind customers you're the best barber in town.

--- a/docs/CLIENT_TRIAL_GUIDE.md
+++ b/docs/CLIENT_TRIAL_GUIDE.md
@@ -1,0 +1,52 @@
+# Belmont SEO Lab — Client Trial Guide
+
+This guide provides a concise link bundle and a 10‑minute demo script for client testing.
+
+## Trial URLs (Production)
+- App: https://seo-lab-echoexes-projects.vercel.app
+- Dashboard: https://seo-lab-echoexes-projects.vercel.app/apps/dashboard
+- GSC CTR Miner: https://seo-lab-echoexes-projects.vercel.app/apps/gsc-ctr-miner
+- UTM Link Builder: https://seo-lab-echoexes-projects.vercel.app/apps/utm-dashboard
+- QR Maker: https://seo-lab-echoexes-projects.vercel.app/apps/utm-qr
+- Review Links: https://seo-lab-echoexes-projects.vercel.app/apps/review-link
+- Review Composer: https://seo-lab-echoexes-projects.vercel.app/apps/review-composer
+- GBP Composer: https://seo-lab-echoexes-projects.vercel.app/apps/gbp-composer
+- Rank Grid: https://seo-lab-echoexes-projects.vercel.app/apps/rank-grid
+
+Diagnostics:
+- Robots: https://seo-lab-echoexes-projects.vercel.app/robots.txt
+- Sitemap: https://seo-lab-echoexes-projects.vercel.app/sitemap.xml
+- Health: https://seo-lab-echoexes-projects.vercel.app/api/health
+- AI Status: https://seo-lab-echoexes-projects.vercel.app/api/ai/status
+
+## 10‑Minute Demo Script
+1) Dashboard
+- Click "Load Demo Metrics" to populate KPI cards and charts.
+- Export a quick metrics CSV from the dashboard snapshot.
+
+2) UTM Link Builder
+- In Link Builder, enter booking URL (https://thebelmontbarber.ca/book), choose a preset, click "Build UTM Link".
+- Copy the generated URL.
+
+3) QR Maker
+- Paste the UTM URL; pick size; generate and download QR code PNG.
+
+4) Review Links
+- Verify Google review link is present; copy Email/SMS templates.
+- Preview the printable in‑shop review QR card.
+
+5) GSC CTR Miner
+- Load Belmont sample data; go to Analytics → "Run Analytics".
+- Open Opportunities to view missed clicks; export recommendations.
+
+6) GBP Composer
+- Generate a Belmont‑branded post and copy for posting.
+
+7) Rank Grid
+- Load demo data in Grid Input; show empty vs populated grid.
+
+## Notes
+- Accessibility: WCAG 2.1 AA (100% in automated suite).
+- Visual stability: Full baselines captured; responsive views covered.
+- Health warning about Redis is informational; production uses in‑memory fallback unless Upstash Redis is configured.
+


### PR DESCRIPTION
Adds docs/CLIENT_TRIAL_GUIDE.md with a link bundle and 10‑minute demo script; updates README with production URL.